### PR TITLE
Add locks back for port operations. 

### DIFF
--- a/templates/plumgrid_plugin.py.erb
+++ b/templates/plumgrid_plugin.py.erb
@@ -178,6 +178,7 @@ class NeutronPluginPLUMgridV2(db_base_plugin_v2.NeutronDbPluginV2,
             except Exception as err_message:
                 raise plum_excep.PLUMgridException(err_msg=err_message)
 
+    @utils.synchronized('plumlib', external=True)
     def create_port(self, context, port):
         """Create Neutron port.
 
@@ -227,6 +228,7 @@ class NeutronPluginPLUMgridV2(db_base_plugin_v2.NeutronDbPluginV2,
         # Plugin DB - Port Create and Return port
         return self._port_viftype_binding(context, port_db)
 
+    @utils.synchronized('plumlib', external=True)
     def update_port(self, context, port_id, port):
         """Update Neutron port.
 
@@ -268,6 +270,7 @@ class NeutronPluginPLUMgridV2(db_base_plugin_v2.NeutronDbPluginV2,
         # Plugin DB - Port Update
         return self._port_viftype_binding(context, port_db)
 
+    @utils.synchronized('plumlib', external=True)
     def delete_port(self, context, port_id, l3_port_check=True):
         """Delete Neutron port.
 


### PR DESCRIPTION
Neutron has a bug where DB ops have errors when accessed parallel. 
https://bugs.launchpad.net/neutron/+bug/1381536 
